### PR TITLE
JWTトークン付与

### DIFF
--- a/src/components/BattleResult.jsx
+++ b/src/components/BattleResult.jsx
@@ -13,7 +13,7 @@ export default function BattleResult() {
   useEffect(() => {
 
     // ローカルストレージからJWTトークンを取得
-    const token = localStorage.getItem("authToken");
+    const token = localStorage.getItem("jwt");
 
     if (!token) {
       alert("ログインが必要です。");

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -37,7 +37,6 @@ const Login = () =>{
             if (data.token) {
                 localStorage.setItem("jwt", data.token);
                 localStorage.setItem("userId", data.userId);
-         //console.log("保存されたトークン:", localStorage.getItem("authToken")); 
                 alert("ログインに成功しました!");
                 navigate("/"); // ログイン成功後にホーム画面に遷移
             } else {

--- a/src/components/RoomJoin.jsx
+++ b/src/components/RoomJoin.jsx
@@ -8,6 +8,13 @@ export default function RoomJoin() {
   const [formErrors, setFormErrors] = useState({});
   const [statusMessage, setStatusMessage] = useState(null);
   const navigate = useNavigate(); // ページ遷移用
+  // ローカルストレージからJWTトークンを取得
+  const token = localStorage.getItem("jwt");
+  if (!token) {
+    alert("ログインが必要です。");
+    navigate("/login");
+    return;
+  }
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -25,6 +32,7 @@ export default function RoomJoin() {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
           },
           body: JSON.stringify({ password: formValues.password }),
         });

--- a/src/components/RoomMake.jsx
+++ b/src/components/RoomMake.jsx
@@ -8,6 +8,13 @@ export default function RoomMake() {
   const [formErrors, setFormErrors] = useState({});
   const [statusMessage, setStatusMessage] = useState(null);
   const navigate = useNavigate(); // ページ遷移用
+  // ローカルストレージからJWTトークンを取得
+  const token = localStorage.getItem("jwt");
+  if (!token) {
+    alert("ログインが必要です。");
+    navigate("/login");
+    return;
+  }
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -25,6 +32,7 @@ export default function RoomMake() {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
           },
           body: JSON.stringify({ roomName: formValues.roomname }),
         });


### PR DESCRIPTION
## 実装内容
- ルーム作成・ルーム参加時にJWTトークンを付与してリクエストを送信することでログインしていないユーザーが不正にゲームを始めることを防ぐ